### PR TITLE
Fix missing return status for LmHandlerJoin

### DIFF
--- a/Middlewares/Third_Party/LoRaWAN/LmHandler/LmHandler.c
+++ b/Middlewares/Third_Party/LoRaWAN/LmHandler/LmHandler.c
@@ -589,8 +589,10 @@ TimerTime_t LmHandlerGetDutyCycleWaitTime( void )
     return DutyCycleWaitTime;
 }
 
-void LmHandlerJoin( ActivationType_t mode, bool forceRejoin )
+LmHandlerErrorStatus_t LmHandlerJoin( ActivationType_t mode, bool forceRejoin )
 {
+    LmHandlerErrorStatus_t lmhStatus = LORAMAC_HANDLER_ERROR;
+    LoRaMacStatus_t status;
     MlmeReq_t mlmeReq;
 
     mlmeReq.Type = MLME_JOIN;
@@ -605,7 +607,12 @@ void LmHandlerJoin( ActivationType_t mode, bool forceRejoin )
         LoRaMacStart();
 #if (defined( LORAMAC_VERSION ) && ( LORAMAC_VERSION == 0x01000300 ))
         /* Starts the OTAA join procedure */
-        LoRaMacMlmeRequest( &mlmeReq );
+        status = LoRaMacMlmeRequest( &mlmeReq );
+
+        if( status == LORAMAC_STATUS_OK )
+        {
+            lmhStatus = LORAMAC_STATUS_OK;
+        }
 #endif /* LORAMAC_VERSION */
     }
     else
@@ -655,7 +662,7 @@ void LmHandlerJoin( ActivationType_t mode, bool forceRejoin )
         {
             LmHandlerCallbacks->OnJoinRequest( &JoinParams );
         }
-        LmHandlerRequestClass( LmHandlerParams.DefaultClass );
+        lmhStatus = LmHandlerRequestClass( LmHandlerParams.DefaultClass );
 #endif /* LORAMAC_VERSION */
     }
 
@@ -663,10 +670,17 @@ void LmHandlerJoin( ActivationType_t mode, bool forceRejoin )
     if( ( CtxRestoreDone == false ) || ( forceRejoin == true ) )
     {
         /* Starts the join procedure */
-        LoRaMacMlmeRequest( &mlmeReq );
+        status  = LoRaMacMlmeRequest( &mlmeReq );
+
+        if( status == LORAMAC_STATUS_OK )
+        {
+            lmhStatus = LORAMAC_STATUS_OK;
+        }
     }
     DutyCycleWaitTime = mlmeReq.ReqReturn.DutyCycleWaitTime;
 #endif /* LORAMAC_VERSION */
+
+    return lmhStatus;
 }
 
 LmHandlerFlagStatus_t LmHandlerJoinStatus( void )

--- a/Middlewares/Third_Party/LoRaWAN/LmHandler/LmHandler.h
+++ b/Middlewares/Third_Party/LoRaWAN/LmHandler/LmHandler.h
@@ -394,7 +394,7 @@ LmHandlerErrorStatus_t LmHandlerPingSlotReq( uint8_t periodicity );
  *
  * \retval status Returns \ref LORAMAC_HANDLER_SUCCESS if request has been
  *                processed else if device not yet joined a network \ref LORAMAC_HANDLER_NO_NETWORK_JOINED
-                  else \ref LORAMAC_HANDLER_ERROR
+ *                else \ref LORAMAC_HANDLER_ERROR
  */
 LmHandlerErrorStatus_t LmHandlerRequestClass( DeviceClass_t newClass );
 

--- a/Middlewares/Third_Party/LoRaWAN/LmHandler/LmHandler.h
+++ b/Middlewares/Third_Party/LoRaWAN/LmHandler/LmHandler.h
@@ -368,7 +368,7 @@ TimerTime_t LmHandlerGetDutyCycleWaitTime( void );
  *                processed else if device not yet joined a network \ref LORAMAC_HANDLER_NO_NETWORK_JOINED
  *                else \ref LORAMAC_HANDLER_ERROR
  */
-LmHandlerErrorStatus_t  LmHandlerJoin( ActivationType_t mode, bool forceRejoin );
+LmHandlerErrorStatus_t LmHandlerJoin( ActivationType_t mode, bool forceRejoin );
 
 /*!
  * Check whether the Device is joined to the network

--- a/Middlewares/Third_Party/LoRaWAN/LmHandler/LmHandler.h
+++ b/Middlewares/Third_Party/LoRaWAN/LmHandler/LmHandler.h
@@ -363,8 +363,12 @@ TimerTime_t LmHandlerGetDutyCycleWaitTime( void );
  *
  * \param [in] mode Activation mode (OTAA or ABP)
  * \param [in] forceRejoin Flag to force the rejoin even if LoRaWAN context can be restored
+ *
+ * \retval status Returns \ref LORAMAC_HANDLER_SUCCESS if request has been
+ *                processed else if device not yet joined a network \ref LORAMAC_HANDLER_NO_NETWORK_JOINED
+ *                else \ref LORAMAC_HANDLER_ERROR
  */
-void LmHandlerJoin( ActivationType_t mode, bool forceRejoin );
+LmHandlerErrorStatus_t  LmHandlerJoin( ActivationType_t mode, bool forceRejoin );
 
 /*!
  * Check whether the Device is joined to the network


### PR DESCRIPTION
In OTAA mode, the join procedure may fail due to Retransmission Back-off (see https://lora-developers.semtech.com/documentation/tech-papers-and-guides/the-book/joining-and-rejoining).

In this case, Application will never receive any OnJoinRequest callback an so may stall.

This PR intend allow Application to be aware of such a failure to send Join Request and behave in consequence.