### PR TITLE
[LoRaMac]Optimize code reading and execution conditions and Add functions for use by the outer layer

### DIFF
--- a/Middlewares/Third_Party/LoRaWAN/Mac/LoRaMac.c
+++ b/Middlewares/Third_Party/LoRaWAN/Mac/LoRaMac.c
@@ -1042,6 +1042,10 @@ static void ProcessRadioTxDone( void )
         TimerSetValue( &MacCtx.AckTimeoutTimer, MacCtx.RxWindow2Delay + phyParam.Value );
         TimerStart( &MacCtx.AckTimeoutTimer );
     }
+    else if( MacCtx.NodeAckRequested == false )
+    {
+        MacCtx.McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_OK;
+    }
 #elif (defined( LORAMAC_VERSION ) && (( LORAMAC_VERSION == 0x01000400 ) || ( LORAMAC_VERSION == 0x01010100 )))
     if( MacCtx.NodeAckRequested == true )
     {
@@ -1072,13 +1076,6 @@ static void ProcessRadioTxDone( void )
     }
 
     RegionSetBandTxDone( Nvm.MacGroup2.Region, &txDone );
-
-#if (defined( LORAMAC_VERSION ) && ( LORAMAC_VERSION == 0x01000300 ))
-    if( MacCtx.NodeAckRequested == false )
-    {
-        MacCtx.McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_OK;
-    }
-#endif /* LORAMAC_VERSION */
 }
 
 static void PrepareRxDoneAbort( void )

--- a/Middlewares/Third_Party/LoRaWAN/Mac/LoRaMac.c
+++ b/Middlewares/Third_Party/LoRaWAN/Mac/LoRaMac.c
@@ -316,6 +316,14 @@ typedef struct sLoRaMacCtx
      * Buffer containing the MAC layer commands
      */
     uint8_t MacCommandsBuffer[LORA_MAC_COMMAND_MAX_LENGTH];
+    /*!
+     * Time on air accumulation
+     */
+    uint32_t SumSendTime;
+    /*!
+     * Send count accumulation
+     */
+    uint32_t SumSendCount;
 }LoRaMacCtx_t;
 
 /*!
@@ -4009,6 +4017,9 @@ static LoRaMacStatus_t SendFrameOnChannel( uint8_t channel )
     MacCtx.McpsConfirm.TxPower = txPower;
     MacCtx.McpsConfirm.Channel = channel;
 
+    MacCtx.SumSendCount++;
+    MacCtx.SumSendTime += MacCtx.TxTimeOnAir;
+
     // Store the time on air
     MacCtx.McpsConfirm.TxTimeOnAir = MacCtx.TxTimeOnAir;
     MacCtx.MlmeConfirm.TxTimeOnAir = MacCtx.TxTimeOnAir;
@@ -6668,4 +6679,25 @@ LoRaMacStatus_t LoRaMacDeInitialization( void )
     {
         return LORAMAC_STATUS_BUSY;
     }
+}
+
+uint8_t LoRaMacGetMaxPayloadLength(void)
+{
+    return GetMaxAppPayloadWithoutFOptsLength(Nvm.MacGroup2.ChannelsDatarateDefault);
+}
+
+void LoRaMacSendInfoGet(uint32_t *count, uint32_t *time)
+{
+    if(count != NULL) {
+        *count = MacCtx.SumSendCount;
+    }
+    if(time != NULL) {
+        *time = MacCtx.SumSendTime;
+    }
+}
+
+void LoRaMacSendInfoClear(void)
+{
+    MacCtx.SumSendCount = 0;
+    MacCtx.SumSendTime = 0;
 }

--- a/Middlewares/Third_Party/LoRaWAN/Mac/LoRaMac.h
+++ b/Middlewares/Third_Party/LoRaWAN/Mac/LoRaMac.h
@@ -476,6 +476,26 @@ LoRaMacStatus_t LoRaMacDeInitialization( void );
 
 LoRaMacStatus_t LoRaMacProcessMicForDatablock( uint8_t *buffer, uint32_t size, uint16_t sessionCnt, uint8_t fragIndex, uint32_t descriptor, uint32_t *mic );
 
+/*!
+ * \brief   LoRaMAC gets the maximum application payload length in the absence of the optional FOpt field
+ *
+ * \retval  Max length
+ */
+uint8_t LoRaMacGetMaxPayloadLength( void );
+
+/*!
+ * \brief   LoRaMAC get send info
+ *
+ * \param   [out] count - Send count accumulation
+ * \param   [out] time - Time on air accumulation
+ */
+void LoRaMacSendInfoGet(uint32_t *count, uint32_t *time);
+
+/*!
+ * \brief   LoRaMAC send info clear
+ */
+void LoRaMacSendInfoClear(void);
+
 /*! \} defgroup LORAMAC */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### LoRaMacGetMaxPayloadLength
- This function is provided for external use to obtain the maximum payload and can be used by the program to determine the number of bytes to send

### LoRaMacSendInfoGet && LoRaMacSendInfoClear
- In the application, the current used power and the remaining power are obtained by calculation. So it is necessary to know the number of lora packets and the time in the air